### PR TITLE
feat(stuff): improve migration

### DIFF
--- a/stuff/migrate.tsx
+++ b/stuff/migrate.tsx
@@ -2,25 +2,30 @@ import { url } from "@vendetta/metro/common";
 import { showConfirmationAlert } from "@vendetta/ui/alerts";
 
 import { getClient } from "./types";
+import RNFS from "$/wrappers/RNFS";
 
+// Symbol used so this notice appears only once even when included in multiple plugins
 const sym = Symbol.for("nexpid.vendetta.migrate");
+const filePath = `${RNFS.DocumentDirectoryPath}/vendetta/NexpidMigrate`;
 
-export default function () {
+export default async function () {
   if (getClient() !== "Vendetta") return;
+  const migrationDismissed = await RNFS.exists(filePath);
 
-  if (!window[sym]) {
+  if (!migrationDismissed && !window[sym]) {
     window[sym] = true;
 
     showConfirmationAlert({
       title: "Vendetta EOL",
       content:
-        "Hi, nexx here! I strongly recommend you switch over to Revenge, which is a fork of Vendetta maintained by @palmdevs. (also, this pesky popup will disappear once you do!)",
-      confirmText: "Visit",
+        "Hi there, nexx here! Vendetta was recently discontinued, meaning it could break at any time. I personally recommend that you switch to Revenge - a fork of Vendetta maintained by @palmdevs.",
+      confirmText: "Visit Revenge",
       onConfirm: () =>
         url.openURL(
           "https://github.com/Revenge-mod/Revenge#%EF%B8%8F-installing",
         ),
-      cancelText: "I'll pass",
+      onCancel: async () => await RNFS.writeFile(filePath, "dismissed (maisy was here :3)"),
+      cancelText: "I'll pass (hide this popup forever)",
     });
   }
 }


### PR DESCRIPTION
i didn't like how the migration popup would appear _every_ launch, nor the wording used, so this pr:
* rewords the migration notice in various ways
* adds persistency to the popup, so the user only has to dismiss it once

i tested this in various ways, including different combinations of adding PluginBrowser and CloudSync since those two currently use the migration function - and it all worked.