### PR TITLE
fix(plugin-embed): do not render non-plugin *.github.io/* links

### DIFF
--- a/src/plugins/plugin-embeds/src/stuff/patcher.ts
+++ b/src/plugins/plugin-embeds/src/stuff/patcher.ts
@@ -32,18 +32,18 @@ export default () => {
 									HTTP_REGEX_MULTI,
 								) ?? []
 							) {
-								const pluginURLMatchers: (string | RegExp)[] = [
-									constants.PROXY_PREFIX,
-									"https://vendetta.nexpid.xyz/", // :3
-									/^https?:\/\/\w+\.github\.io\//i,
-								];
-								if (pluginURLMatchers.some(x =>
-									x instanceof RegExp
-										? x.test(url.toLowerCase())
-										: url
-											.toLowerCase()
-											.startsWith(x.toLowerCase())
-								)
+								if (
+									[
+										constants.PROXY_PREFIX,
+										"https://vendetta.nexpid.xyz/", // :3
+										/^https?:\/\/\w+\.github\.io\//i,
+									].some(x =>
+										x instanceof RegExp
+											? x.test(url.toLowerCase())
+											: url
+												.toLowerCase()
+												.startsWith(x.toLowerCase())
+									)
 								) {
 									plugins.push(
 										!url.endsWith("/") ? `${url}/` : url,
@@ -96,7 +96,8 @@ export default () => {
 
 						row.message.codedLinks ??= [];
 						codedLinksCache[row.message.id][
-							row.message.codedLinks.push(getCodedLink(plugin)) - 1
+							row.message.codedLinks.push(getCodedLink(plugin))
+							- 1
 						] = plugin;
 					}
 				}

--- a/src/plugins/plugin-embeds/src/stuff/patcher.ts
+++ b/src/plugins/plugin-embeds/src/stuff/patcher.ts
@@ -32,18 +32,18 @@ export default () => {
 									HTTP_REGEX_MULTI,
 								) ?? []
 							) {
-								if (
-									[
-										constants.PROXY_PREFIX,
-										"https://vendetta.nexpid.xyz/", // :3
-										/^https?:\/\/\w+\.github\.io\//i,
-									].some(x =>
-										x instanceof RegExp
-											? x.test(url.toLowerCase())
-											: url
-												.toLowerCase()
-												.startsWith(x.toLowerCase())
-									)
+								const pluginURLMatchers: (string | RegExp)[] = [
+									constants.PROXY_PREFIX,
+									"https://vendetta.nexpid.xyz/", // :3
+									/^https?:\/\/\w+\.github\.io\//i,
+								];
+								if (pluginURLMatchers.some(x =>
+									x instanceof RegExp
+										? x.test(url.toLowerCase())
+										: url
+											.toLowerCase()
+											.startsWith(x.toLowerCase())
+								)
 								) {
 									plugins.push(
 										!url.endsWith("/") ? `${url}/` : url,
@@ -96,8 +96,7 @@ export default () => {
 
 						row.message.codedLinks ??= [];
 						codedLinksCache[row.message.id][
-							row.message.codedLinks.push(getCodedLink(plugin))
-							- 1
+							row.message.codedLinks.push(getCodedLink(plugin)) - 1
 						] = plugin;
 					}
 				}

--- a/src/plugins/plugin-embeds/src/stuff/plugins.ts
+++ b/src/plugins/plugin-embeds/src/stuff/plugins.ts
@@ -66,29 +66,25 @@ export const getCodedLink = (plugin: string) => {
 	const info = getPluginInfo(plugin).res;
 	const installing = pluginInstallingCache[plugin];
 
-	if (info === false) {
-		obj.headerText = "...";
-	} else if (info === null) {
-		obj.headerText = "unknown plugin";
-	} else {
-		obj.titleText = info.name;
-		obj.noParticipantsText = `\n${info.description}`;
-		obj.ctaEnabled = !installing;
+	if (info === null || info === false) return null;
 
-		const has = !!plugins[plugin];
-		obj.acceptLabelBackgroundColor = androidifyColor(
-			resolveSemanticColor(
-				!has || installing
-					? semanticColors.BUTTON_POSITIVE_BACKGROUND
-					: semanticColors.BUTTON_DANGER_BACKGROUND,
-			),
-		);
-		obj.acceptLabelText = installing
-			? "..."
-			: has
+	obj.titleText = info.name;
+	obj.noParticipantsText = `\n${info.description}`;
+	obj.ctaEnabled = !installing;
+
+	const has = !!plugins[plugin];
+	obj.acceptLabelBackgroundColor = androidifyColor(
+		resolveSemanticColor(
+			!has || installing
+				? semanticColors.BUTTON_POSITIVE_BACKGROUND
+				: semanticColors.BUTTON_DANGER_BACKGROUND,
+		),
+	);
+	obj.acceptLabelText = installing
+		? "..."
+		: has
 			? "Uninstall Plugin"
 			: "Install Plugin";
-	}
 
 	return obj;
 };


### PR DESCRIPTION
It should not render embed if the `*.github.io/*` is not returning plugin manifest file anymore

addressing this issue: https://github.com/nexpid/RevengePlugins/issues/128